### PR TITLE
jQuery.fn.load() is deprecated

### DIFF
--- a/assets/js/uix-shortcodes.js
+++ b/assets/js/uix-shortcodes.js
@@ -35,7 +35,7 @@ var uix_sc = (function ( $, window, document ) {
 	if( $.isFunction( $.fn.waitForImages ) ){
 		$( 'body' ).waitForImages( pageLoaded );
 	} else {
-		$( window ).load( pageLoaded );
+		$( window ).on( 'load', pageLoaded );
 	}
 
     $( document ).ready( documentReady );


### PR DESCRIPTION
Fixes deprecated console notice when using plugin